### PR TITLE
Add functionality to cancel existing duplicate builds

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -188,6 +188,14 @@ retry:
 		return
 	}
 
+	// cancel existing jenkins builds associated with the job
+	for _, build := range builds {
+		if err := config.cancelJenkinsBuild(baseRepo, pr.Number, build); err != nil {
+			log.Error(err)
+			w.WriteHeader(500)
+		}
+	}
+
 	// schedule the jenkins builds
 	for _, build := range builds {
 		if !build.Downstream {

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -117,9 +117,9 @@ func (c *Client) BuildWithParameters(job string, parameters string) error {
 }
 
 
-func (c *Client) GetJobInstance(job string, pr_number int, sha string) (int, error) {
+func (c *Client) GetJobInstance(job string, pr_number int) (int, error) {
 	// set up the request
-	url := fmt.Sprintf("%s/job/%s/api/xml?tree=builds[number,result,actions[parameters[name,value]]]&xpath=/freeStyleProject/build[action/parameter[name=\"PR\"][value=\"%v\"]][action/parameter[name=\"GIT_SHA1\"][value=\"%s\"]][not(result)]&wrapper=found_jobs", c.Baseurl, job, pr_number, sha)
+	url := fmt.Sprintf("%s/job/%s/api/xml?tree=builds[number,result,actions[parameters[name,value]]]&xpath=/freeStyleProject/build[action/parameter[name=\"PR\"][value=\"%v\"]][not(result)]&wrapper=found_jobs", c.Baseurl, job, pr_number)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return 0, err
@@ -136,10 +136,6 @@ func (c *Client) GetJobInstance(job string, pr_number int, sha string) (int, err
 	}
 
 	reqDump, err := httputil.DumpRequestOut(req, true)
-    if err != nil {
-        log.Fatal(err)
-    }
-
 	fmt.Printf("REQUEST:\n%s", string(reqDump))
 
 	// check the status code

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -162,7 +162,7 @@ func (c *Client) CancelJobInstance(job string, job_id int) error {
 	log.Infof("cancelling job instance, job: %s, job number: %v", job, job_id)
 
 	// set up the request
-	url := fmt.Sprintf("%s/job/%s/%s/stop", c.Baseurl, job, job_id)
+	url := fmt.Sprintf("%s/job/%s/%v/stop", c.Baseurl, job, job_id)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte{}))
 	if err != nil {
 		return err

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -179,8 +179,8 @@ func (c *Client) CancelJobInstance(job string, job_id int) error {
 	}
 
 	// check the status code
-	// it should be 201 - need to check this.
-	if resp.StatusCode != 201 {
+	// it should be 200
+	if resp.StatusCode != 200 {
 		return fmt.Errorf("jenkins post to %s responded with status %d", url, resp.StatusCode)
 	}
 

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -115,7 +115,7 @@ func (c *Client) BuildWithParameters(job string, parameters string) error {
 }
 
 
-func (c *Client) GetJobInstance(job string, pr_number string, sha string) (int, error) {
+func (c *Client) GetJobInstance(job string, pr_number int, sha string) (int, error) {
 	// set up the request
 	url := fmt.Sprintf("%s/job/%s/api/xml?tree=builds[number,result,actions[parameters[name,value]]]&xpath=/freeStyleProject/build[action/parameter[name=\"PR\"][value=\"%s\"]][action/parameter[name=\"GIT_SHA1\"][value=\"%s\"]][not(result)]&wrapper=found_jobs", c.Baseurl, job, pr_number, sha)
 	req, err := http.NewRequest("GET", url, nil)

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -144,12 +144,12 @@ func (c *Client) GetJobInstance(job string, pr_number int) (int, error) {
 	// read then parse response for job id
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		panic(err)
+		return 0, err
 	}
 
 	var jobInstance = &JobInstance{}
 	if err := xml.Unmarshal(body, &jobInstance); err != nil {
-		panic(err)
+		return 0, err
 	}
 
 	return jobInstance.Number, nil

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -135,6 +135,13 @@ func (c *Client) GetJobInstance(job string, pr_number int, sha string) (int, err
 		return 0, err
 	}
 
+	reqDump, err := httputil.DumpRequestOut(req, true)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+	fmt.Printf("REQUEST:\n%s", string(reqDump))
+
 	// check the status code
 	// it should be 200
 	if resp.StatusCode != 200 {
@@ -174,12 +181,6 @@ func (c *Client) CancelJobInstance(job string, job_id int) error {
 	if err != nil {
 		return err
 	}
-	if err != nil {
-        log.Fatal(err)
-    }
-
-	reqDump, err := httputil.DumpRequestOut(req, true)
-	fmt.Printf("REQUEST:\n%s", string(reqDump))
 
 	// check the status code
 	// it should be 201 - need to check this.

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -125,9 +125,6 @@ func (c *Client) GetJobInstance(job string, pr_number int) (int, error) {
 		return 0, err
 	}
 
-	// add the auth - Not sure this will be needed for GET
-	req.SetBasicAuth(c.Username, c.Token)
-
 	// do the request
 	client := &http.Client{}
 	resp, err := client.Do(req)
@@ -144,12 +141,12 @@ func (c *Client) GetJobInstance(job string, pr_number int) (int, error) {
 		return 0, fmt.Errorf("jenkins get to %s responded with status %d", url, resp.StatusCode)
 	}
 
+	// read then parse response for job id
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		panic(err)
 	}
 
-	//parse response for job id
 	var jobInstance = &JobInstance{}
 	if err := xml.Unmarshal(body, &jobInstance); err != nil {
 		panic(err)

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"encoding/xml"
 	"io/ioutil"
+	"strconv"
 )
 
 type Client struct {
@@ -117,7 +118,7 @@ func (c *Client) BuildWithParameters(job string, parameters string) error {
 
 func (c *Client) GetJobInstance(job string, pr_number int, sha string) (int, error) {
 	// set up the request
-	url := fmt.Sprintf("%s/job/%s/api/xml?tree=builds[number,result,actions[parameters[name,value]]]&xpath=/freeStyleProject/build[action/parameter[name=\"PR\"][value=\"%s\"]][action/parameter[name=\"GIT_SHA1\"][value=\"%s\"]][not(result)]&wrapper=found_jobs", c.Baseurl, job, pr_number, sha)
+	url := fmt.Sprintf("%s/job/%s/api/xml?tree=builds[number,result,actions[parameters[name,value]]]&xpath=/freeStyleProject/build[action/parameter[name=\"PR\"][value=\"%s\"]][action/parameter[name=\"GIT_SHA1\"][value=\"%s\"]][not(result)]&wrapper=found_jobs", c.Baseurl, job, strconv.Itoa(pr_number), sha)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return 0, err

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"encoding/xml"
 	"io/ioutil"
+	log "github.com/Sirupsen/logrus"
+	"net/http/httputil"
 )
 
 type Client struct {
@@ -154,6 +156,8 @@ func (c *Client) GetJobInstance(job string, pr_number int, sha string) (int, err
 }
 
 func (c *Client) CancelJobInstance(job string, job_id int) error {
+	log.Infof("cancelling job instance, job: %s, job number: %v", job, job_id)
+
 	// set up the request
 	url := fmt.Sprintf("%s/job/%s/%s/stop", c.Baseurl, job, job_id)
 	req, err := http.NewRequest("POST", url, bytes.NewBuffer([]byte{}))
@@ -170,6 +174,12 @@ func (c *Client) CancelJobInstance(job string, job_id int) error {
 	if err != nil {
 		return err
 	}
+	if err != nil {
+        log.Fatal(err)
+    }
+
+	reqDump, err := httputil.DumpRequestOut(req, true)
+	fmt.Printf("REQUEST:\n%s", string(reqDump))
 
 	// check the status code
 	// it should be 201 - need to check this.

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -134,9 +134,9 @@ func (c *Client) GetJobInstance(job string, pr_number int, sha string) (int, err
 	}
 
 	// check the status code
-	// it should be 201
-	if resp.StatusCode != 201 {
-		return 0, fmt.Errorf("jenkins post to %s responded with status - test %d", url, resp.StatusCode)
+	// it should be 200
+	if resp.StatusCode != 200 {
+		return 0, fmt.Errorf("jenkins get to %s responded with status %d", url, resp.StatusCode)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/jenkins/jenkins.go
+++ b/jenkins/jenkins.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"encoding/xml"
 	"io/ioutil"
-	"strconv"
 )
 
 type Client struct {
@@ -118,7 +117,7 @@ func (c *Client) BuildWithParameters(job string, parameters string) error {
 
 func (c *Client) GetJobInstance(job string, pr_number int, sha string) (int, error) {
 	// set up the request
-	url := fmt.Sprintf("%s/job/%s/api/xml?tree=builds[number,result,actions[parameters[name,value]]]&xpath=/freeStyleProject/build[action/parameter[name=\"PR\"][value=\"%s\"]][action/parameter[name=\"GIT_SHA1\"][value=\"%s\"]][not(result)]&wrapper=found_jobs", c.Baseurl, job, strconv.Itoa(pr_number), sha)
+	url := fmt.Sprintf("%s/job/%s/api/xml?tree=builds[number,result,actions[parameters[name,value]]]&xpath=/freeStyleProject/build[action/parameter[name=\"PR\"][value=\"%v\"]][action/parameter[name=\"GIT_SHA1\"][value=\"%s\"]][not(result)]&wrapper=found_jobs", c.Baseurl, job, pr_number, sha)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return 0, err
@@ -137,7 +136,7 @@ func (c *Client) GetJobInstance(job string, pr_number int, sha string) (int, err
 	// check the status code
 	// it should be 201
 	if resp.StatusCode != 201 {
-		return 0, fmt.Errorf("jenkins post to %s responded with status %d", url, resp.StatusCode)
+		return 0, fmt.Errorf("jenkins post to %s responded with status - test %d", url, resp.StatusCode)
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)

--- a/utils.go
+++ b/utils.go
@@ -204,7 +204,7 @@ func (c Config) cancelJenkinsBuild(baseRepo string, number int, build Build) err
 	}
 
 	// get the shas to build
-	_, pr, err := c.getShas(r[0], r[1], build.Context, number)
+	shas, pr, err := c.getShas(r[0], r[1], build.Context, number)
 	if err != nil {
 		return err
 	}
@@ -215,7 +215,8 @@ func (c Config) cancelJenkinsBuild(baseRepo string, number int, build Build) err
 		j := &c.Jenkins
 		// cancel any existing builds
 		// get job ID
-		if job_id, err := j.GetJobInstance(build.Job, pr.Number, sha); err != nil {
+		job_id, err := j.GetJobInstance(build.Job, pr.Number, sha)
+		if err != nil {
 			return fmt.Errorf("error retrieving jenkins job instance: %v", err)
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -224,6 +224,8 @@ func (c Config) cancelJenkinsBuild(baseRepo string, number int, build Build) err
 			if err := j.CancelJobInstance(build.Job, job_id); err != nil {
 				return fmt.Errorf("error cancelling jenkins build: %v", err)
 			}
+		} else {
+			log.Infof("No job number found related to %s, %v, %s", build.Job, pr.Number, sha)
 		}
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -195,6 +195,40 @@ func (c Config) scheduleJenkinsBuild(baseRepo string, number int, build Build) e
 	return nil
 }
 
+func (c Config) cancelJenkinsBuild(baseRepo string, number int, build Build) error {
+	// parse git repo for username
+	// and repo name
+	r := strings.SplitN(baseRepo, "/", 2)
+	if len(r) < 2 {
+		return fmt.Errorf("repo name could not be parsed: %s", baseRepo)
+	}
+
+	// get the shas to build
+	_, pr, err := c.getShas(r[0], r[1], build.Context, number)
+	if err != nil {
+		return err
+	}
+
+	for _, sha := range shas {
+
+		// setup the jenkins client
+		j := &c.Jenkins
+		// cancel any existing builds
+		// get job ID
+		if job_id, err := j.GetJobInstance(build.Job, pr.Number, sha); err != nil {
+			return fmt.Errorf("error retrieving jenkins job instance: %v", err)
+		}
+
+		if job_id != 0 {
+			if err := j.CancelJobInstance(build.Job, job_id); err != nil {
+				return fmt.Errorf("error cancelling jenkins build: %v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
 func (c Config) scheduleJenkinsDownstreamBuild(baseRepo string, headRepo string, number int, build Build, sha string) error {
 	// update the github status
 	if err := c.updateGithubStatus(baseRepo, build.Context, sha, "pending", "Jenkins build is being scheduled", c.Jenkins.Baseurl+"/job/"+build.Job); err != nil {


### PR DESCRIPTION
This PR adds the functionality to cancel existing builds on our fork of Leeroy.

When a push is made to a PR Leeroy will now search Jenkins for running builds relating to that PR, and cancel them.

Test this on staging server b.

Note: Please use the staging documentation to see how to setup Jenkins/Leeroy: https://github.com/mantidproject/ansible-linode/tree/main/docs/staging

**In addition:**

In your `ansible-linode` repo you will have to edit the `roles/leeroy/defaults/main.yml` file so that `leeroy_binary_url` is `https://github.com/mantidproject/leeroy/releases/download/test/leeroy`

You will then have to `ssh` onto the staging server, cd to `/home/leeroy` and from that directory delete the `leeroy` file.  Following this, then `pgrep leeroy` to get the `pid` associated with `Leeroy` and kill it using `sudo kill <pid>`.

You can now run the update ansible playbook with the `leeroy` tag to launch the updated version of `Leeroy`.

When Leeroy is running, push a commit to a PR on the `mantid-staging` repo. When the PR job is running, push again and observe that the initial job is cancelled.